### PR TITLE
update AsyncStorage

### DIFF
--- a/src/defaults/persist.native.js
+++ b/src/defaults/persist.native.js
@@ -1,6 +1,6 @@
 // @flow
 // $FlowIgnore
-import { AsyncStorage } from 'react-native'; // eslint-disable-line
+import { AsyncStorage } from '@react-native-async-storage/async-storage'; // eslint-disable-line
 import { persistStore } from 'redux-persist';
 
 export default (store: any, options: {}, callback: any) =>


### PR DESCRIPTION
update AsyncStorage to play with Expo sdk 41, which uses https://github.com/react-native-async-storage/async-storage